### PR TITLE
Reduced Version Headers in HTTP responses

### DIFF
--- a/src/FunnelWeb.Web/Global.asax.cs
+++ b/src/FunnelWeb.Web/Global.asax.cs
@@ -83,6 +83,8 @@ namespace FunnelWeb.Web
 
         private void Application_Start()
         {
+            MvcHandler.DisableMvcResponseHeader = true;
+
             AreaRegistration.RegisterAllAreas();
 
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);

--- a/src/FunnelWeb.Web/Web.config
+++ b/src/FunnelWeb.Web/Web.config
@@ -22,7 +22,7 @@
       </providers>
     </roleManager>
     <customErrors mode="Off" defaultRedirect="/search" />
-    <httpRuntime requestValidationMode="2.0" maxRequestLength="200000" />
+    <httpRuntime requestValidationMode="2.0" maxRequestLength="200000" enableVersionHeader="false" />
     <compilation debug="true" targetFramework="4.0" />
     <httpHandlers>
       <add path="*.aspx" verb="*" type="System.Web.HttpNotFoundHandler" />
@@ -55,6 +55,11 @@
       <add name="LowercaseUrls" type="FunnelWeb.Web.Application.ForceLowercaseUrlHttpModule, FunnelWeb.Web" />
       <add name="RequireUpdatedDatabase" type="FunnelWeb.Web.Application.RequireUpdatedDatabaseHttpModule, FunnelWeb.Web" />
     </modules>
+    <httpProtocol>
+      <customHeaders>
+        <remove name="X-Powered-By"/>
+      </customHeaders>
+    </httpProtocol>
     <handlers>
       <remove name="BlockViewHandler" />
       <add name="BlockViewHandler" path="*.aspx" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />


### PR DESCRIPTION
By default ASP.NET and MVC include version information in the HTTP header of every response. Divulging the software version information is a minor security hole, but it is also adding needless payload to every response.

I have deployed the changes to my site hosted in an Azure website. Here are the HTTP headers in the response for the home page showing before and after the change. This was captured using [fiddler](http://www.fiddler2.com/fiddler2/).
### Before

```
HTTP/1.1 200 OK
Cache-Control: private
Content-Length: 4074
Content-Type: text/html; charset=utf-8
Server: Microsoft-IIS/7.5
Set-Cookie: ARRAffinity=obscured to protect the innocent
X-AspNetMvc-Version: 4.0
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
X-Powered-By: ARR/2.5
X-Powered-By: ASP.NET
Date: Sun, 04 Nov 2012 12:17:39 GMT
```
### After

```
HTTP/1.1 200 OK
Cache-Control: private
Content-Length: 4074
Content-Type: text/html; charset=utf-8
Server: Microsoft-IIS/7.5
Set-Cookie: ARRAffinity=obscured to protect the innocent
X-Powered-By: ARR/2.5
X-Powered-By: ASP.NET
Date: Sun, 04 Nov 2012 12:34:47 GMT
```

As shown `X-AspNetMvc-Version`, `X-AspNet-Version` and one of the `X-Powered-By: ASP.NET` headers have been removed. The remainder are from the hosting infrastructure and I can't find a way to remove them when hosted in an Azure website.
