### PR TITLE
Slug auto-complete bug

### DIFF
--- a/src/FunnelWeb.Web/Areas/Admin/Controllers/WikiAdminController.cs
+++ b/src/FunnelWeb.Web/Areas/Admin/Controllers/WikiAdminController.cs
@@ -72,12 +72,17 @@ namespace FunnelWeb.Web.Areas.Admin.Controllers
                 return View(model);
             }
 
-            // Does an entry with that name already exist?
-            var existing = Repository.FindFirstOrDefault(new EntryByNameQuery(model.Name));
-            if (existing != null && existing.Id != model.Id)
+            if (CurrentEntryExistsWithName(model.Name))
             {
                 model.SelectedTags = GetEditTags(model);
-                ModelState.AddModelError("PageExists", string.Format("A page with SLUG '{0}' already exists. You should edit that page instead.", model.Title));
+                ModelState.AddModelError("PageExists", string.Format("A page with SLUG '{0}' already exists. You should edit that page instead", model.Name));
+                return View(model);
+            }
+
+            if (CurrentEntryExistsWithName(model.Title) && model.Name == "")
+            {
+                model.SelectedTags = GetEditTags(model);
+                ModelState.AddModelError("PageExists", string.Format("A page with SLUG '{0}' already exists. Please add a unique SLUG here.", model.Title));
                 return View(model);
             }
 
@@ -128,6 +133,11 @@ namespace FunnelWeb.Web.Areas.Admin.Controllers
             }
 
             return RedirectToAction("Page", "Wiki", new { Area = "", page = entry.Name});
+        }
+
+        private bool CurrentEntryExistsWithName(string name)
+        {
+            return Repository.FindFirstOrDefault(new EntryByNameQuery(name)) != null;
         }
 
         private List<Tag> GetEditTags(EntryRevision model)

--- a/src/FunnelWeb.Web/My.config
+++ b/src/FunnelWeb.Web/My.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<funnelweb xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <setting key="funnelweb.configuration.database.connection" value="database=FunnelWeb;server=.\SQLEXPRESS;trusted_connection=true;" />
+<funnelweb xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <setting key="funnelweb.configuration.database.connection" value="database=FunnelWeb;server=.\SQLEXPRESS;User Id=sa;Password=test;" />
   <setting key="funnelweb.configuration.database.schema" value="dbo" />
   <setting key="funnelweb.configuration.authentication.username" value="test" />
   <setting key="funnelweb.configuration.authentication.password" value="test" />


### PR DESCRIPTION
Hey,

Looks like if I create a post with just the content populated I get a SLUG of : New post, which is collected from the form in the section 'Title'. This is fine on first creation but if I create a second item and funnelweb does this again I get an exception when on the query because its trying to add an item with the same SLUG. So I have changed the validation to detect this and make the user create a unique slug on the second item created (with only content section filled out).
Hope its okay?
Pete
