### PR TITLE
Use request.IsSecureConnection if no 'X-Forwarded-Proto' header

### DIFF
--- a/src/FunnelWeb/Utilities/HttpRequestExtensions.cs
+++ b/src/FunnelWeb/Utilities/HttpRequestExtensions.cs
@@ -37,7 +37,10 @@ namespace FunnelWeb.Utilities
 			// When the application is run behind a load-balancer (or forward proxy), request.IsSecureConnection returns 'true' or 'false'
 			// based on the request from the load-balancer to the web server (e.g. IIS) and not the actual request to the load-balancer.
 			// The same is also applied to request.Url.Scheme (or uriBuilder.Scheme, as in our case).
-			bool isSecureConnection = String.Equals(request.Headers["X-Forwarded-Proto"], "https", StringComparison.OrdinalIgnoreCase);
+			bool isSecureConnection =
+			    string.IsNullOrWhiteSpace(request.Headers["X-Forwarded-Proto"])
+			        ? request.IsSecureConnection
+			        : String.Equals(request.Headers["X-Forwarded-Proto"], "https", StringComparison.OrdinalIgnoreCase);
 
 			if (isSecureConnection)
 			{


### PR DESCRIPTION
`GetOriginalUrl` was only taking into account the _'X-Forwarded-Proto'_ HTTP header in determining whether the request was a secure connection. This header is not present in non load balanced environments or in Azure (websites and cloud services).

Therefore where there is no _'X-Forwarded-Proto'_ HTTP header fallback to using `request.IsSecureConnection`
