### PR TITLE
Fixed DirectoryNotFoundException if no Scripts/Views

### DIFF
--- a/src/FunnelWeb.Web/Application/Mvc/ViewBundleRegistrar.cs
+++ b/src/FunnelWeb.Web/Application/Mvc/ViewBundleRegistrar.cs
@@ -49,9 +49,12 @@ namespace FunnelWeb.Web.Application.Mvc
         {
             string path = HttpContext.Current.Server.MapPath("Scripts/Views");
 
-            foreach (string jsFile in Directory.EnumerateFiles(path, "*.js", SearchOption.AllDirectories))
+            if (Directory.Exists(path))
             {
-                bundles.Add(CreateScriptBundle(jsFile, path));
+                foreach (string jsFile in Directory.EnumerateFiles(path, "*.js", SearchOption.AllDirectories))
+                {
+                    bundles.Add(CreateScriptBundle(jsFile, path));
+                }
             }
         }
 


### PR DESCRIPTION
The method `RegisterViewBundles` was crashing with a `DirectoryNotFoundException` if _Scripts/Views_ did not exist.

The fix is identical to the commit f6e10e5246a2b80593c778eb080998a23d0ad505 which looks like it was fixing the same issue.
