### PR TITLE
Fixed extracting a zip file issue when uploading files

### DIFF
--- a/src/FunnelWeb/Providers/File/FileRepositoryBase.cs
+++ b/src/FunnelWeb/Providers/File/FileRepositoryBase.cs
@@ -22,7 +22,7 @@ namespace FunnelWeb.Providers.File
         protected static bool IsZipFile(string fullPath)
         {
             var extension = Path.GetExtension(fullPath).ToLowerInvariant();
-            return extension == "zip" || extension == "gz" || extension == "tar" || extension == "rar";
+            return extension == ".zip" || extension == ".gz" || extension == ".tar" || extension == ".rar";
         }
 
         public abstract bool IsFile(string path);


### PR DESCRIPTION
If you select to unzip your file upload today it won't be unzipped.

The bug was in the check for zip extension. It was
checking for "zip" instead of ".zip". Path.GetExtension
includes the "."

See
"http://msdn.microsoft.com/en-us/library/system.io.path.getextension.aspx"
