### PR TITLE
An unauthenticated user can delete a post / page

### DIFF
--- a/src/FunnelWeb.Web/Areas/Admin/Controllers/WikiAdminController.cs
+++ b/src/FunnelWeb.Web/Areas/Admin/Controllers/WikiAdminController.cs
@@ -153,6 +153,7 @@ namespace FunnelWeb.Web.Areas.Admin.Controllers
             return tagList;
         }
 
+        [Authorize(Roles = "Moderator")]
         [HttpPost]
         public virtual ActionResult DeletePage(int id)
         {


### PR DESCRIPTION
The DeletePage action does not have the authorize attribute. The following javascript would delete a post/page with id X if fed the complete url to delete, (if a post/page w/ that id exists) even if the user is not authenticated!

``` javascript
$.ajax({
   type:'POST',
   url: '<the_url_to_delete_post/page>',
   success: function(){
       alert('success');
   }
});
```
