### PR TITLE
Fix null identifier exception when saving settings

### DIFF
--- a/src/FunnelWeb/Model/Repositories/Internal/AdminRepository.cs
+++ b/src/FunnelWeb/Model/Repositories/Internal/AdminRepository.cs
@@ -34,11 +34,15 @@ namespace FunnelWeb.Model.Repositories.Internal
 
         public void Save(IEnumerable<Setting> settings)
         {
-            foreach (var setting in settings)
+            using (var transaction = session.BeginTransaction())
             {
-                session.SaveOrUpdate(setting);               
+                foreach (var setting in settings)
+                {
+                    session.SaveOrUpdate(setting);
+                }
+                transaction.Commit();
+                session.Flush();
             }
-            session.Flush();
         }
     }
 }


### PR DESCRIPTION
While using a SqlCe provider, I've discovered that I wasn't able to save settings after a clean clone from the repository. 

AdminRepository.Save throws a "null identifier" an exception when calling saveOrUpdate when inserting new items with id of 0;

To fix I've wrapped it in the transaction as suggested here: http://stackoverflow.com/questions/982513/nhibernate-null-identifier-exception-after-inserting-an-entity

and it works like a charm.

To reproduce, using sql ce, after fresh install go to the admin/settings and click save.
![image](https://f.cloud.github.com/assets/159128/2298531/d35f02f4-a0be-11e3-83a7-940bd66f9cc2.png)
